### PR TITLE
Remove production dependency on dialyxer

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Error.MixProject do
 
   defp deps do
     [
-      {:dialyxir, "~> 0.5.1", runtime: false},
+      {:dialyxir, "~> 0.5.1", only: :test, runtime: false},
       {:ex_doc, "~> 0.21.2", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
This dependency is only used for CI. A consumer of the library does not have a need for it.
:D