### PR TITLE
Convenience functions for nested errors handling

### DIFF
--- a/lib/error.ex
+++ b/lib/error.ex
@@ -122,11 +122,11 @@ defmodule Error do
   def caused_by(%InfraError{caused_by: c}), do: c
 
   @doc """
-  Flattens the given error and all its nested causes into list.
+  Flattens the given error and all its nested causes into a list.
 
-  Given error is always the first element of resulting list.
+  The given error is always the first element of resulting list.
   """
-  @spec flatten(t(a)) :: [t(a)] when a: map
+  @spec flatten(t(a)) :: [t(a)] when a: any
   def flatten(%DomainError{} = e), do: caused_by(e) |> flatten_rec([e])
   def flatten(%InfraError{} = e), do: caused_by(e) |> flatten_rec([e])
 
@@ -134,11 +134,11 @@ defmodule Error do
   defp flatten_rec({:just, e}, acc), do: caused_by(e) |> flatten_rec([e | acc])
 
   @doc """
-  Extracts the root cause of given error.
+  Extracts the root cause of the given error.
 
-  The root cause of error without cause is the error itself.
+  The root cause of an error without an underlying cause is the error itself.
   """
-  @spec root_cause(t(a)) :: t(a) when a: map
+  @spec root_cause(t(a)) :: t(a) when a: any
   def root_cause(e), do: flatten(e) |> List.last()
 
   @doc """

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -113,16 +113,6 @@ defmodule Error do
   end
 
   @doc """
-  Convenience to extract cause of error and unwrap it from `{:just, error}` tuple.
-  """
-  @spec unwrap(t(a)) :: t(a) | :nothing when a: map
-  def unwrap(%DomainError{} = e), do: caused_by(e) |> do_unwrap()
-  def unwrap(%InfraError{} = e), do: caused_by(e) |> do_unwrap()
-
-  defp do_unwrap({:just, c}), do: c
-  defp do_unwrap(c), do: c
-
-  @doc """
   Extract the cause of an error (of type `Error.t()`).
 
   Think of this as inspecting deeper into the stack trace.
@@ -137,11 +127,11 @@ defmodule Error do
   Given error is always the first element of resulting list.
   """
   @spec flatten(t(a)) :: [t(a)] when a: map
-  def flatten(%DomainError{} = e), do: flatten_rec(e, [])
-  def flatten(%InfraError{} = e), do: flatten_rec(e, [])
+  def flatten(%DomainError{} = e), do: caused_by(e) |> flatten_rec([e])
+  def flatten(%InfraError{} = e), do: caused_by(e) |> flatten_rec([e])
 
   defp flatten_rec(:nothing, acc), do: Enum.reverse(acc)
-  defp flatten_rec(e, acc), do: unwrap(e) |> flatten_rec([e | acc])
+  defp flatten_rec({:just, e}, acc), do: caused_by(e) |> flatten_rec([e | acc])
 
   @doc """
   Extracts the root cause of given error.

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -57,32 +57,6 @@ defmodule ErrorTest do
              }
   end
 
-  test "a domain error can be unwrapped from previously wrapped error" do
-    inner = Error.domain(:inner)
-    wrapped_domain_error = Error.wrap(inner, Error.domain(:outer))
-    wrapped_infra_error = Error.wrap(inner, Error.domain(:outer))
-
-    assert Error.unwrap(wrapped_domain_error) == inner
-    assert Error.unwrap(wrapped_infra_error) == inner
-  end
-
-  test "an infra error can be unwrapped from previously wrapped error" do
-    inner = Error.infra(:inner)
-    wrapped_by_domain_error = Error.wrap(inner, Error.domain(:outer))
-    wrapped_infra_error = Error.wrap(inner, Error.domain(:outer))
-
-    assert Error.unwrap(wrapped_by_domain_error) == inner
-    assert Error.unwrap(wrapped_infra_error) == inner
-  end
-
-  test "unwrapping error without a cause should return :nothing" do
-    infra = Error.infra(:infra)
-    domain = Error.domain(:domain)
-
-    assert :nothing == Error.unwrap(infra)
-    assert :nothing == Error.unwrap(domain)
-  end
-
   test "error kind can be accessed" do
     error = Error.domain(:r, %{})
     assert Error.kind(error) == :domain

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -57,6 +57,32 @@ defmodule ErrorTest do
              }
   end
 
+  test "a domain error can be unwrapped from previously wrapped error" do
+    inner = Error.domain(:inner)
+    wrapped_domain_error = Error.wrap(inner, Error.domain(:outer))
+    wrapped_infra_error = Error.wrap(inner, Error.domain(:outer))
+
+    assert Error.unwrap(wrapped_domain_error) == inner
+    assert Error.unwrap(wrapped_infra_error) == inner
+  end
+
+  test "an infra error can be unwrapped from previously wrapped error" do
+    inner = Error.infra(:inner)
+    wrapped_by_domain_error = Error.wrap(inner, Error.domain(:outer))
+    wrapped_infra_error = Error.wrap(inner, Error.domain(:outer))
+
+    assert Error.unwrap(wrapped_by_domain_error) == inner
+    assert Error.unwrap(wrapped_infra_error) == inner
+  end
+
+  test "unwrapping error without a cause should return :nothing" do
+    infra = Error.infra(:infra)
+    domain = Error.domain(:domain)
+
+    assert :nothing == Error.unwrap(infra)
+    assert :nothing == Error.unwrap(domain)
+  end
+
   test "error kind can be accessed" do
     error = Error.domain(:r, %{})
     assert Error.kind(error) == :domain
@@ -165,5 +191,41 @@ defmodule ErrorTest do
       end
 
     assert m == :not_matched
+  end
+
+  test "should flatten multiple nested errors" do
+    root_cause = Error.domain(:root)
+    layer_1 = Error.wrap(root_cause, Error.domain(:layer1))
+    layer_2 = Error.wrap(layer_1, Error.infra(:layer2))
+    layer_3 = Error.wrap(layer_2, Error.infra(:layer3))
+    layer_4 = Error.wrap(layer_3, Error.domain(:layer4))
+
+    assert [layer_4, layer_3, layer_2, layer_1, root_cause] == Error.flatten(layer_4)
+  end
+
+  test "flatten of non-nested error should just return it" do
+    infra = Error.infra(:infra)
+    domain = Error.domain(:domain)
+
+    assert [infra] == Error.flatten(infra)
+    assert [domain] == Error.flatten(domain)
+  end
+
+  test "should retrieve root cause of multiple nested errors" do
+    root_cause = Error.domain(:root)
+    layer_1 = Error.wrap(root_cause, Error.domain(:layer1))
+    layer_2 = Error.wrap(layer_1, Error.infra(:layer2))
+    layer_3 = Error.wrap(layer_2, Error.infra(:layer3))
+    layer_4 = Error.wrap(layer_3, Error.domain(:layer4))
+
+    assert root_cause == Error.root_cause(layer_4)
+  end
+
+  test "root cause of non-nested error is the error itself" do
+    infra = Error.infra(:infra)
+    domain = Error.domain(:domain)
+
+    assert infra == Error.root_cause(infra)
+    assert domain == Error.root_cause(domain)
   end
 end


### PR DESCRIPTION
Adding new convenience functions for nested errors handling:

- ~~`unwrap/1` - to extract cause of an error and unwrap it from `{:just, error}` tuple~~ (removed after review),
- `flatten/1` - to flatten the given error and all its nested causes into list,
- `root_cause/1` - to extract to root cause of an error, even with multiple levels of nesting.