### PR TITLE
Make typings more liberal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,12 @@ need to know about the `Error` type.
 
 ## Pattern-matching
 
-If you'd like to pattern-match on errors, you will find that Dialyzer rejects
-your attempts, complaining that the Error.InfraError and Error.DomainError
-structs are opaque. The way to get around this without breaking opacity is by
-importing the guard `is_error`, or the specific guards `is_infra_error` and
-`is_domain_error`.
+If you'd like to pattern-match on errors, it's possible to match directly on the
+`Error.InfraError` and `Error.DomainError` structs, however it's **strongly  discouraged**.  
+The best way of testing for domain or infra errors are dedicated guards. Import the guard `is_error`,
+or the specific guards `is_infra_error` and `is_domain_error` and use them in the match clauses:
 
 ```
-
-# DIALYZER WILL REJECT THIS
-
-    case something() do
-        {:ok, %MyItem{} = i} -> handle(i)
-        {:error, %DomainError{} = e} -> Error.reason(e)
-        {:error, :some_atom} -> other_path()
-    end
-
-# DIALYZER WILL ACCEPT THIS
 
     import Error, only: [is_error: 1]
     case something() do

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -17,17 +17,17 @@ defmodule Error do
 
   @type kind :: :domain | :infra
   @type reason :: atom()
-  @opaque t(a) ::
-            %DomainError{reason: reason, details: a}
-            | %InfraError{reason: reason, details: a}
+  @type t(a) ::
+          %DomainError{reason: reason, details: a}
+          | %InfraError{reason: reason, details: a}
 
-  @opaque t :: t(map())
+  @type t :: t(any())
 
-  @opaque domain(a) :: %DomainError{reason: reason, details: a}
-  @opaque domain() :: domain(map())
+  @type domain(a) :: %DomainError{reason: reason, details: a}
+  @type domain() :: domain(any())
 
-  @opaque infra(a) :: %InfraError{reason: reason, details: a}
-  @opaque infra() :: infra(map())
+  @type infra(a) :: %InfraError{reason: reason, details: a}
+  @type infra() :: infra(any())
 
   @doc """
   A guard to use in order to pattern match errors.
@@ -50,7 +50,7 @@ defmodule Error do
   @doc """
   Create a `domain` error, with a reason and optional details.
   """
-  @spec domain(atom(), a) :: t(a) when a: map
+  @spec domain(atom(), a) :: t(a) when a: any
   def domain(reason, details \\ %{}) when is_atom(reason) and is_map(details) do
     %DomainError{reason: reason, details: details, caused_by: :nothing}
   end
@@ -58,7 +58,7 @@ defmodule Error do
   @doc """
   Create an `infra` error, with a reason and optional details.
   """
-  @spec infra(atom(), a) :: t(a) when a: map
+  @spec infra(atom(), a) :: t(a) when a: any
   def infra(reason, details \\ %{}) when is_atom(reason) and is_map(details) do
     %InfraError{reason: reason, details: details, caused_by: :nothing}
   end
@@ -80,7 +80,7 @@ defmodule Error do
   @doc """
   Return the map of detailed information supplied at `Error` creation.
   """
-  @spec details(t(a)) :: a when a: map
+  @spec details(t(a)) :: a when a: any
   def details(%DomainError{details: details}), do: details
   def details(%InfraError{details: details}), do: details
 
@@ -89,7 +89,7 @@ defmodule Error do
 
   Useful for adding extra details, modifying exisint ones, or removing them.
   """
-  @spec map_details(t(a), (a -> b)) :: t(b) when a: map, b: map
+  @spec map_details(t(a), (a -> b)) :: t(b) when a: any, b: any
   def map_details(%DomainError{details: details} = error, f) do
     %DomainError{error | details: f.(details)}
   end
@@ -103,7 +103,7 @@ defmodule Error do
 
   Think of this as a stack trace, but in domain-model terms.
   """
-  @spec wrap(t(a), t(a)) :: t(a) when a: map
+  @spec wrap(t(a), t(a)) :: t(a) when a: any
   def wrap(inner, %DomainError{} = outer) do
     %{outer | caused_by: Maybe.just(inner)}
   end
@@ -117,7 +117,7 @@ defmodule Error do
 
   Think of this as inspecting deeper into the stack trace.
   """
-  @spec caused_by(t(a)) :: Maybe.t(t(a)) when a: map
+  @spec caused_by(t(a)) :: Maybe.t(t(a)) when a: any
   def caused_by(%DomainError{caused_by: c}), do: c
   def caused_by(%InfraError{caused_by: c}), do: c
 


### PR DESCRIPTION
Changing @opaque types into regular ones because without this dialyzer rejects both
direct struct matching with `Error.DomainError` or `Error.InfraError` structs, and prevents
usage of `is_error/1`, `is_domain_error/1` and `is_infra_error/1` guards.

Additionally changing specs of some of the functions because they were forcing `Error.t(map())`
type on their arguments.